### PR TITLE
Add mistral-small-latest to AGENT_CAPABLE_MODELS

### DIFF
--- a/custom_components/mistral_conversation/const.py
+++ b/custom_components/mistral_conversation/const.py
@@ -61,6 +61,7 @@ CHAT_MODELS = [
 
 # Models that support the Agents/Conversations API (required for web search)
 AGENT_CAPABLE_MODELS = [
+    "mistral-small-latest",
     "mistral-medium-latest",
     "mistral-medium-2505",
     "mistral-large-latest",


### PR DESCRIPTION
mistral-small-latest is agentic capable and can search the web. I tested this with my local HA installation.

https://docs.mistral.ai/models/model-cards/mistral-small-4-0-26-03

mistral-small-latest is way faster / cheeper than medium or large. for me it give the best cost / usage ration with being "smart".