### PR TITLE
Make web search opt-in per turn instead of routing every utterance

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@
    - [Available models](#available-models)
    - [System prompt](#system-prompt)
    - [Continue conversation (Experimental)](#continue-conversation-experimental)
+   - [Web search (Beta)](#web-search-beta)
 7. [Controlling devices](#controlling-devices)
 8. [Using as a service action](#using-as-a-service-action)
 9. [Speech recognition (STT)](#speech-recognition-stt)
@@ -61,6 +62,7 @@ This integration makes **Mistral AI** available as a fully-featured conversation
 | Jinja2 system prompt | ✅ | Templates with `{{ now() }}`, `{{ ha_name }}` etc. |
 | Multilingual | ✅ | Responds in the user's language |
 | Continue conversation | ✅ | Keeps microphone open after questions (Experimental) |
+| Web search | ✅ | Model-decided web search via the Agents API, or trigger phrases (Beta) |
 | Separate devices | ✅ | Conversation and STT appear as separate HA devices |
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
@@ -138,6 +140,9 @@ Click the integration → **Configure** to change settings.
 | **Max tokens** | `1024` | Maximum response length |
 | **Control HA** | On | Allow the AI to control exposed devices |
 | **Continue conversation** | Off | Keep listening after questions (Experimental) |
+| **Web search** | Off | Allow the AI to search the web (Beta) |
+| **Web search routing** | `Let the model decide` | How web search is triggered — see below |
+| **Web search trigger phrases** | *(empty)* | Optional phrases that force a web search — see below |
 | **STT language** | Auto-detect | Language for Voxtral transcription |
 | **TTS mode** | `Streaming` | `Streaming` (SSE WAV with sentence-level pipelining) or `Batch` (single MP3 request) |
 ### Available models
@@ -179,6 +184,45 @@ Do not use markdown formatting that cannot be read aloud, such as asterisks for 
 When enabled, the assistant automatically keeps the microphone open after any response that contains a question (`?`). This is implemented using the native `continue_conversation` flag in HA's `ConversationResult` — no separate automation is needed.
 
 > **Note:** This feature requires a satellite device that supports `assist_satellite.start_conversation`. Behaviour may vary between satellite types.
+
+### Web search (Beta)
+
+Web search is only available through Mistral's **Agents API**, which is a separate,
+slower endpoint than the regular chat completions call and **cannot carry Home
+Assistant tools**. A turn answered by the Agents API therefore cannot control
+your devices. Requires an agent-capable model (`mistral-small-latest`,
+`mistral-medium-latest` or `mistral-large-latest`).
+
+**Web search routing** controls when that endpoint is used:
+
+| Mode | Behaviour |
+|---|---|
+| **Let the model decide** (default) | Web search is offered to the model as a tool. It searches only when it judges a search is needed, and Home Assistant tools stay available — so one turn can search *and* control devices. |
+| **Always search** | Legacy behaviour: every request goes to the Agents API. Slower, and device control does not work on those turns. |
+
+> **Performance note:** enabling web search with **Always search** routes *every*
+> utterance — including "turn on the lamp" — through the Agents API. Use
+> **Let the model decide**, or set trigger phrases, to keep ordinary commands on
+> the fast path.
+
+**Web search trigger phrases** (optional) is a comma-separated list, for example:
+
+```
+search for, look up, google
+```
+
+When it is non-empty it **takes precedence over the routing mode**: only utterances
+that *start with* one of the phrases search the web (the phrase itself is stripped
+from the query), and every other utterance never searches. If several phrases
+match, the longest one wins. Matching is case-insensitive. Leave the field empty
+to let the routing mode decide.
+
+Trigger phrases are language-specific, so nothing is shipped by default. Dutch
+users might use `zoek op, zoek online, google`; German users `suche, google`.
+
+> Note: with trigger phrases set, a matching turn goes straight to the Agents API
+> and so cannot control devices — that is the same trade-off as **Always search**,
+> just limited to utterances you opt into.
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
 
@@ -321,6 +365,15 @@ A: Mistral AI processes requests via their servers. See their [privacy policy](h
 ---
 
 ## Release Notes
+
+### Unreleased
+- **Fixed:** With web search enabled, *every* utterance was routed through the Agents API — including plain device commands. That path never passed Home Assistant tools, so device control silently failed on it (the model replies "I can't perform physical actions"). Web search is now opt-in per turn. Fixes #29.
+- **Added:** `web_search_mode` option. Default `model` advertises web search to the model as a tool and services the call against the Agents API, so a turn keeps its HA tools and can search *and* control devices. `always` preserves the previous behaviour.
+- **Added:** `web_search_trigger` option — optional comma-separated phrases (empty by default). When set it takes precedence over `web_search_mode`: only utterances starting with a phrase search (phrase stripped, longest match wins, case-insensitive); all others never search.
+- **Fixed:** Assistant turns carrying neither text nor tool calls are no longer sent to Mistral — they were rejected with HTTP 400 `Assistant message must have either content or tool_calls, but not none.` (code 3240).
+- **Added:** 29 unit tests for trigger resolution, tool-call interception, and the content-less-assistant-turn guard.
+
+---
 
 ### 2026.05 — 2026-05-04
 - **Changed:** Version numbering from digits to year.month.version format.

--- a/custom_components/mistral_conversation/config_flow.py
+++ b/custom_components/mistral_conversation/config_flow.py
@@ -22,6 +22,8 @@ from .const import (
     CONF_TTS_MODE,
     CONF_TTS_VOICE,
     CONF_WEB_SEARCH,
+    CONF_WEB_SEARCH_MODE,
+    CONF_WEB_SEARCH_TRIGGER,
     DEFAULT_CONTINUE_CONVERSATION,
     DEFAULT_MAX_TOKENS,
     DEFAULT_MODEL,
@@ -30,10 +32,13 @@ from .const import (
     DEFAULT_TTS_MODE,
     DEFAULT_TTS_VOICE,
     DEFAULT_WEB_SEARCH,
+    DEFAULT_WEB_SEARCH_MODE,
+    DEFAULT_WEB_SEARCH_TRIGGER,
     DOMAIN,
     MISTRAL_API_BASE,
     TTS_MODES,
     TTS_VOICES,
+    WEB_SEARCH_MODES,
 )
 from .stt import LANGUAGE_OPTIONS
 
@@ -228,6 +233,34 @@ class MistralOptionsFlow(config_entries.OptionsFlow):
                         CONF_WEB_SEARCH,
                         default=opts.get(CONF_WEB_SEARCH, DEFAULT_WEB_SEARCH),
                     ): selector.BooleanSelector(),
+                    # ── Web search routing ────────────────────────────────
+                    # 'model': the model calls a web_search tool when it needs
+                    # one, keeping HA tools available on the same turn.
+                    # 'always': legacy — every turn goes to the Agents API,
+                    # which is slower and carries no HA tools.
+                    vol.Optional(
+                        CONF_WEB_SEARCH_MODE,
+                        default=opts.get(
+                            CONF_WEB_SEARCH_MODE, DEFAULT_WEB_SEARCH_MODE
+                        ),
+                    ): selector.SelectSelector(
+                        selector.SelectSelectorConfig(
+                            options=WEB_SEARCH_MODES,
+                            mode=selector.SelectSelectorMode.DROPDOWN,
+                            translation_key="web_search_mode",
+                        )
+                    ),
+                    # ── Web search trigger phrases (optional) ─────────────
+                    # Comma-separated. When set, these take precedence over the
+                    # routing mode: only utterances starting with one of them
+                    # search (phrase stripped), everything else never does.
+                    # Empty = let the mode above decide.
+                    vol.Optional(
+                        CONF_WEB_SEARCH_TRIGGER,
+                        default=opts.get(
+                            CONF_WEB_SEARCH_TRIGGER, DEFAULT_WEB_SEARCH_TRIGGER
+                        ),
+                    ): selector.TextSelector(),
                     # ── TTS voice (fallback default) ──────────────────────
                     # Primary voice selection is in Settings → Voice Assistants.
                     # This setting is used as fallback when no voice is chosen

--- a/custom_components/mistral_conversation/const.py
+++ b/custom_components/mistral_conversation/const.py
@@ -11,6 +11,8 @@ CONF_MAX_TOKENS = "max_tokens"
 CONF_TEMPERATURE = "temperature"
 CONF_CONTINUE_CONVERSATION = "continue_conversation"
 CONF_WEB_SEARCH = "web_search"
+CONF_WEB_SEARCH_MODE = "web_search_mode"
+CONF_WEB_SEARCH_TRIGGER = "web_search_trigger"
 CONF_STT_LANGUAGE = "stt_language"
 CONF_TTS_VOICE = "tts_voice"
 CONF_TTS_MODE = "tts_mode"
@@ -21,6 +23,22 @@ TTS_MODE_STREAM = "stream"
 TTS_MODE_BATCH = "batch"
 TTS_MODES = [TTS_MODE_STREAM, TTS_MODE_BATCH]
 
+# web_search_mode values
+#   model  — the model decides per turn by calling a `web_search` tool. Keeps
+#            HA tools available, so one turn can both search and control devices.
+#   always — legacy behaviour: every turn goes to the Agents API (no HA tools).
+WEB_SEARCH_MODE_MODEL = "model"
+WEB_SEARCH_MODE_ALWAYS = "always"
+WEB_SEARCH_MODES = [WEB_SEARCH_MODE_MODEL, WEB_SEARCH_MODE_ALWAYS]
+
+# Name of the synthetic function tool the model calls to request a web search.
+# Mistral's built-in {"type": "web_search"} tool is NOT accepted by
+# /v1/chat/completions (HTTP 400 "WebSearchTool connector is not supported",
+# code 1800) even though the API reference lists it in the `tools` union — it is
+# only honoured on /v1/agents and /v1/conversations. So we expose web search as
+# an ordinary function tool and service the call ourselves via the Agents API.
+WEB_SEARCH_TOOL_NAME = "web_search"
+
 # ---------------------------------------------------------------------------
 # Defaults
 # ---------------------------------------------------------------------------
@@ -29,6 +47,13 @@ DEFAULT_MAX_TOKENS = 1024
 DEFAULT_TEMPERATURE = 0.7  # Mistral range: 0.0–1.0
 DEFAULT_CONTINUE_CONVERSATION = False
 DEFAULT_WEB_SEARCH = False
+DEFAULT_WEB_SEARCH_MODE = WEB_SEARCH_MODE_MODEL
+# Optional comma-separated trigger phrases. When non-empty they are LEADING:
+# an utterance starting with one of them is sent straight to the Agents API
+# (phrase stripped), and anything else skips web search entirely. Empty (the
+# default) leaves routing to `web_search_mode`. Opt-in by design — trigger
+# phrases are language-specific, so shipping a list would only fit some users.
+DEFAULT_WEB_SEARCH_TRIGGER = ""
 DEFAULT_STT_LANGUAGE = ""  # empty = Voxtral auto-detect
 DEFAULT_TTS_VOICE = "en_paul_neutral"
 DEFAULT_TTS_MODE = TTS_MODE_STREAM

--- a/custom_components/mistral_conversation/conversation.py
+++ b/custom_components/mistral_conversation/conversation.py
@@ -30,14 +30,20 @@ from .const import (
     CONF_PROMPT,
     CONF_TEMPERATURE,
     CONF_WEB_SEARCH,
+    CONF_WEB_SEARCH_MODE,
+    CONF_WEB_SEARCH_TRIGGER,
     DEFAULT_CONTINUE_CONVERSATION,
     DEFAULT_MAX_TOKENS,
     DEFAULT_MODEL,
     DEFAULT_TEMPERATURE,
     DEFAULT_WEB_SEARCH,
+    DEFAULT_WEB_SEARCH_MODE,
+    DEFAULT_WEB_SEARCH_TRIGGER,
     DOMAIN,
     MAX_TOOL_ITERATIONS,
     MISTRAL_API_BASE,
+    WEB_SEARCH_MODE_ALWAYS,
+    WEB_SEARCH_TOOL_NAME,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -99,6 +105,69 @@ def _to_mistral_id(ha_id: str) -> str:
     return hashlib.md5(ha_id.encode()).hexdigest()[:9]
 
 
+def _web_search_tool_def() -> dict[str, Any]:
+    """Return the synthetic ``web_search`` function tool offered to the model.
+
+    Mistral's built-in ``{"type": "web_search"}`` tool is rejected by
+    /v1/chat/completions, so web search is advertised as a normal function and
+    serviced by us against the Agents API. The description is what steers the
+    model, so it states both when to use it and when not to — without it the
+    model reaches for search on questions it can answer locally.
+    """
+    return {
+        "type": "function",
+        "function": {
+            "name": WEB_SEARCH_TOOL_NAME,
+            "description": (
+                "Search the public web for information you do not already know: "
+                "current events, news, sports results, prices, opening hours, or "
+                "facts that change over time. Do NOT use this to control or query "
+                "devices in this home, and do not use it for general knowledge you "
+                "can already answer."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "query": {
+                        "type": "string",
+                        "description": (
+                            "The search query. Make it self-contained — resolve any "
+                            "pronouns or context from the conversation first."
+                        ),
+                    }
+                },
+                "required": ["query"],
+            },
+        },
+    }
+
+
+def _resolve_trigger(text: str, trigger: str) -> tuple[bool, str]:
+    """Match ``text`` against comma-separated trigger phrases.
+
+    Returns ``(matched, query)``. When matched, ``query`` is ``text`` with the
+    trigger phrase removed (a leading ``:`` or whitespace after it is stripped
+    too). If several phrases match, the LONGEST wins so that "zoek online"
+    beats a bare "zoek". Matching is case-insensitive and ignores surrounding
+    whitespace. An empty ``trigger`` never matches.
+
+    A stripped query can come back empty (utterance was only the phrase, e.g.
+    just "google"); callers must treat that as "no usable query".
+    """
+    phrases = [p.strip().lower() for p in (trigger or "").split(",") if p.strip()]
+    if not phrases:
+        return False, text
+
+    stripped = text.strip()
+    lowered = stripped.lower()
+    matches = [p for p in phrases if lowered.startswith(p)]
+    if not matches:
+        return False, text
+
+    matched = max(matches, key=len)
+    return True, stripped[len(matched):].lstrip(" :").strip()
+
+
 def _convert_chat_log_to_messages(
     chat_log: conversation.ChatLog,
 ) -> list[dict[str, Any]]:
@@ -119,6 +188,14 @@ def _convert_chat_log_to_messages(
             messages.append({"role": "user", "content": str(content.content)})
 
         elif isinstance(content, conversation.AssistantContent):
+            # Skip turns that carry neither text nor tool calls. Mistral rejects
+            # those with "Assistant message must have either content or
+            # tool_calls, but not none." (HTTP 400, code 3240). A turn like this
+            # occurs when the only tool call in it was intercepted by us (see
+            # the web_search interception in _async_handle_message).
+            if not content.content and not content.tool_calls:
+                continue
+
             if content.tool_calls:
                 all_have_results = all(tc.id in tool_results for tc in content.tool_calls)
                 if not all_have_results:
@@ -273,6 +350,43 @@ async def _async_stream_delta(
                         yield item
 
 
+async def _filter_intercepted_tool(
+    stream: AsyncGenerator[dict[str, Any], None],
+    tool_name: str,
+    collected: list[str],
+) -> AsyncGenerator[dict[str, Any], None]:
+    """Strip calls to ``tool_name`` from a delta stream, collecting their queries.
+
+    The named tool is one we service ourselves (web search via the Agents API),
+    so HA must never see it — it isn't in HA's LLM API and executing it would
+    raise. Each intercepted call's ``query`` argument is appended to
+    ``collected``; a call with no usable query is dropped silently.
+
+    Deltas that end up with an empty ``tool_calls`` list are suppressed entirely,
+    since chat_log treats an empty list as a malformed delta.
+    """
+    async for delta in stream:
+        tool_calls = delta.get("tool_calls")
+        if not tool_calls:
+            yield delta
+            continue
+
+        kept = []
+        for tc in tool_calls:
+            if getattr(tc, "tool_name", None) != tool_name:
+                kept.append(tc)
+                continue
+            args = getattr(tc, "tool_args", None) or {}
+            query = args.get("query") if isinstance(args, dict) else None
+            if isinstance(query, str) and query.strip():
+                collected.append(query.strip())
+            else:
+                _LOGGER.debug("Ignoring %s call without a usable query", tool_name)
+
+        if kept:
+            yield {**delta, "tool_calls": kept}
+
+
 # ---------------------------------------------------------------------------
 # Entity
 # ---------------------------------------------------------------------------
@@ -343,39 +457,90 @@ class MistralConversationEntity(ConversationEntity):
         max_tokens = int(opts.get(CONF_MAX_TOKENS, DEFAULT_MAX_TOKENS))
         temperature = max(0.0, min(1.0, float(opts.get(CONF_TEMPERATURE, DEFAULT_TEMPERATURE))))
         web_search = opts.get(CONF_WEB_SEARCH, DEFAULT_WEB_SEARCH)
+        web_search_mode = opts.get(CONF_WEB_SEARCH_MODE, DEFAULT_WEB_SEARCH_MODE)
+        web_search_trigger = opts.get(
+            CONF_WEB_SEARCH_TRIGGER, DEFAULT_WEB_SEARCH_TRIGGER
+        )
 
-        # --- Web search path: Agents/Conversations API -------------------
-        if web_search and any(model.startswith(m) for m in AGENT_CAPABLE_MODELS):
-            system_content = chat_log.content[0] if chat_log.content else None
-            system_prompt = (
-                system_content.content if hasattr(system_content, "content") else ""
-            )
-            try:
-                ws_reply = await self._conversations_chat(
-                    model=model,
-                    system_prompt=system_prompt,
-                    user_text=user_input.text,
-                    conv_id=chat_log.conversation_id,
-                )
-            except HomeAssistantError as err:
-                _LOGGER.debug("Web search failed, falling back to chat completions: %s", err)
-                ws_reply = None
+        # Web search needs an agent-capable model — it is only reachable through
+        # the Agents/Conversations API.
+        web_search_available = web_search and any(
+            model.startswith(m) for m in AGENT_CAPABLE_MODELS
+        )
 
-            if ws_reply:
-                should_continue = continue_conversation_enabled and "?" in ws_reply
-                intent_response = intent.IntentResponse(language=user_input.language)
-                intent_response.async_set_speech(ws_reply)
-                return ConversationResult(
-                    response=intent_response,
-                    conversation_id=chat_log.conversation_id,
-                    continue_conversation=should_continue,
+        # Trigger phrases, when configured, are leading: a match goes straight to
+        # the Agents API and a non-match skips web search for this turn. An empty
+        # trigger list (the default) leaves the decision to web_search_mode.
+        trigger_matched, trigger_query = _resolve_trigger(
+            user_input.text, web_search_trigger if web_search_available else ""
+        )
+        has_trigger = bool((web_search_trigger or "").strip()) and web_search_available
+
+        # Offer web search as a tool only when the model is the one deciding.
+        offer_web_search_tool = (
+            web_search_available
+            and not has_trigger
+            and web_search_mode != WEB_SEARCH_MODE_ALWAYS
+        )
+        if offer_web_search_tool:
+            tools = (tools or []) + [_web_search_tool_def()]
+
+        # --- Direct web search path: Agents/Conversations API -------------
+        # Used when a trigger phrase matched, or in legacy "always" mode. This
+        # path carries no HA tools, so device control cannot happen on it.
+        use_direct_web_search = web_search_available and (
+            trigger_matched
+            or (not has_trigger and web_search_mode == WEB_SEARCH_MODE_ALWAYS)
+        )
+        if use_direct_web_search:
+            # A trigger-only utterance ("google") leaves nothing to search for;
+            # fall through to the normal path rather than querying for "".
+            search_text = trigger_query if trigger_matched else user_input.text
+            if not search_text.strip():
+                _LOGGER.debug(
+                    "Web search trigger matched but query was empty; "
+                    "falling through to chat completions"
                 )
+            else:
+                system_content = chat_log.content[0] if chat_log.content else None
+                system_prompt = (
+                    system_content.content if hasattr(system_content, "content") else ""
+                )
+                try:
+                    ws_reply = await self._conversations_chat(
+                        model=model,
+                        system_prompt=system_prompt,
+                        user_text=search_text,
+                        conv_id=chat_log.conversation_id,
+                    )
+                except HomeAssistantError as err:
+                    _LOGGER.debug(
+                        "Web search failed, falling back to chat completions: %s", err
+                    )
+                    ws_reply = None
+
+                if ws_reply:
+                    should_continue = continue_conversation_enabled and "?" in ws_reply
+                    intent_response = intent.IntentResponse(language=user_input.language)
+                    intent_response.async_set_speech(ws_reply)
+                    return ConversationResult(
+                        response=intent_response,
+                        conversation_id=chat_log.conversation_id,
+                        continue_conversation=should_continue,
+                    )
 
         # --- Standard path: chat completions with tool-call loop ---------
+        # Synthetic messages holding web-search results. They live only in the
+        # outgoing payload, never in chat_log, so conversation history stays a
+        # clean user/assistant transcript.
+        injected: list[dict[str, Any]] = []
+        # Queries the model asked us to search for, captured from the stream.
+        captured_searches: list[str] = []
+
         for _iteration in range(MAX_TOOL_ITERATIONS):
             payload: dict[str, Any] = _sanitize({
                 "model": model,
-                "messages": _convert_chat_log_to_messages(chat_log),
+                "messages": _convert_chat_log_to_messages(chat_log) + injected,
                 "max_tokens": max_tokens,
                 "temperature": temperature,
                 "stream": True,
@@ -384,8 +549,17 @@ class MistralConversationEntity(ConversationEntity):
                 payload["tools"] = tools
                 payload["tool_choice"] = "auto"
 
+            captured_searches.clear()
             try:
-                await self._stream_and_collect(payload, chat_log, user_input)
+                await self._stream_and_collect(
+                    payload,
+                    chat_log,
+                    user_input,
+                    intercept_tool=(
+                        WEB_SEARCH_TOOL_NAME if offer_web_search_tool else None
+                    ),
+                    intercepted=captured_searches,
+                )
             except HomeAssistantError:
                 raise
             except Exception as err:
@@ -393,6 +567,46 @@ class MistralConversationEntity(ConversationEntity):
                 raise HomeAssistantError(
                     f"Unexpected error talking to Mistral: {err}"
                 ) from err
+
+            # The model asked for a web search: service it against the Agents
+            # API and hand the result back on the next round. Checked before
+            # unresponded_tool_results, because an intercepted call leaves no
+            # pending tool result behind.
+            if captured_searches:
+                query = captured_searches[0]
+                _LOGGER.debug("Model requested web search: %s", query)
+                try:
+                    results = await self._conversations_chat(
+                        model=model,
+                        system_prompt=(
+                            "Answer the search query factually and concisely. "
+                            "Cite nothing; plain prose only."
+                        ),
+                        user_text=query,
+                        conv_id=chat_log.conversation_id,
+                    )
+                except HomeAssistantError as err:
+                    _LOGGER.debug("Web search lookup failed: %s", err)
+                    results = ""
+
+                injected.append({
+                    "role": "user",
+                    "content": (
+                        f'Web search results for "{query}":\n'
+                        f"{results or 'No results were returned.'}\n\n"
+                        "Using these results, answer my original question directly. "
+                        "Do not mention that you performed a search."
+                    ),
+                })
+                # Withdraw the tool so a turn can trigger at most one search and
+                # cannot loop on it.
+                tools = [
+                    t
+                    for t in (tools or [])
+                    if t.get("function", {}).get("name") != WEB_SEARCH_TOOL_NAME
+                ] or None
+                offer_web_search_tool = False
+                continue
 
             if not chat_log.unresponded_tool_results:
                 break
@@ -503,8 +717,16 @@ class MistralConversationEntity(ConversationEntity):
         payload: dict[str, Any],
         chat_log: conversation.ChatLog,
         user_input: ConversationInput,
+        intercept_tool: str | None = None,
+        intercepted: list[str] | None = None,
     ) -> None:
-        """POST to Mistral, stream deltas into chat_log."""
+        """POST to Mistral, stream deltas into chat_log.
+
+        When ``intercept_tool`` is set, calls to that tool are removed from the
+        delta stream before chat_log sees them and their ``query`` argument is
+        appended to ``intercepted``. HA would otherwise try to execute a tool
+        that isn't in its LLM API and raise.
+        """
         runtime = self._runtime
         try:
             async with runtime.session.post(
@@ -527,9 +749,15 @@ class MistralConversationEntity(ConversationEntity):
                         f"Mistral API error {resp.status}: {body}"
                     )
 
+                stream = _async_stream_delta(resp)
+                if intercept_tool is not None:
+                    stream = _filter_intercepted_tool(
+                        stream, intercept_tool, intercepted if intercepted is not None else []
+                    )
+
                 async for _content in chat_log.async_add_delta_content_stream(
                     user_input.agent_id,
-                    _async_stream_delta(resp),
+                    stream,
                 ):
                     pass
 

--- a/custom_components/mistral_conversation/strings.json
+++ b/custom_components/mistral_conversation/strings.json
@@ -39,6 +39,8 @@
           "max_tokens": "Maximum tokens in response",
           "continue_conversation": "Enable conversations and listen to responses (Experimental)",
           "web_search": "Enable web search (Beta)",
+          "web_search_mode": "Web search routing",
+          "web_search_trigger": "Web search trigger phrases (optional)",
           "stt_language": "Speech recognition language (STT)",
           "tts_voice": "Text-to-speech voice",
           "tts_mode": "Text-to-speech mode"
@@ -50,7 +52,9 @@
           "temperature": "0 = deterministic, 1 = creative. Mistral range: 0.0–1.0.",
           "max_tokens": "Maximum length of the AI response in tokens.",
           "continue_conversation": "When enabled, the assistant automatically keeps listening after a response that ends with a question. Uses the native HA continue_conversation flag. Experimental: behaviour may vary by satellite.",
-          "web_search": "When enabled, the AI can search the web for up-to-date information. Uses Mistral's Agents API (beta). Requires a model that supports agents (mistral-medium-latest or mistral-large-latest).",
+          "web_search": "When enabled, the AI can search the web for up-to-date information. Uses Mistral's Agents API (beta). Requires a model that supports agents (mistral-small-latest, mistral-medium-latest or mistral-large-latest). See 'Web search routing' below — the 'Always search' option sends every request through the slower Agents API and disables device control for those turns.",
+          "web_search_mode": "'Let the model decide' (recommended): the AI searches only when it decides it needs to, and can still control your devices in the same turn. 'Always search': every request goes through the Agents API — slower, and device control does not work on those turns.",
+          "web_search_trigger": "Optional. Comma-separated phrases, for example 'search for, look up, google'. When set, these take precedence over the routing mode: only commands starting with one of these phrases search the web (the phrase itself is removed from the query), and all other commands never search. Leave empty to let the routing mode decide.",
           "stt_language": "Language for Voxtral speech-to-text. Select 'Auto-detect' to let Voxtral determine the language automatically.",
           "tts_voice": "Voice used by Mistral TTS. 'Nova' is neutral and works well for home automation. All voices support any language.",
           "tts_mode": "Stream: low-latency SSE WAV with sentence-level pipelining. Batch: single mp3 request, higher latency but smaller responses cache well. The tts.speak service always uses batch."
@@ -63,6 +67,12 @@
       "options": {
         "stream": "Streaming",
         "batch": "Batch"
+      }
+    },
+    "web_search_mode": {
+      "options": {
+        "model": "Let the model decide (recommended)",
+        "always": "Always search (legacy, slower)"
       }
     }
   }

--- a/custom_components/mistral_conversation/translations/en.json
+++ b/custom_components/mistral_conversation/translations/en.json
@@ -39,6 +39,8 @@
           "max_tokens": "Maximum tokens in response",
           "continue_conversation": "Enable conversations and listen to responses (Experimental)",
           "web_search": "Enable web search (Beta)",
+          "web_search_mode": "Web search routing",
+          "web_search_trigger": "Web search trigger phrases (optional)",
           "stt_language": "Speech recognition language (STT)",
           "tts_voice": "Text-to-speech voice",
           "tts_mode": "Text-to-speech mode"
@@ -50,7 +52,9 @@
           "temperature": "0 = deterministic, 1 = creative. Mistral range: 0.0–1.0.",
           "max_tokens": "Maximum length of the AI response in tokens.",
           "continue_conversation": "When enabled, the assistant automatically keeps listening after a response that ends with a question. Uses the native HA continue_conversation flag. Experimental: behaviour may vary by satellite.",
-          "web_search": "When enabled, the AI can search the web for up-to-date information. Uses Mistral's Agents API (beta). Requires a model that supports agents (mistral-medium-latest or mistral-large-latest).",
+          "web_search": "When enabled, the AI can search the web for up-to-date information. Uses Mistral's Agents API (beta). Requires a model that supports agents (mistral-small-latest, mistral-medium-latest or mistral-large-latest). See 'Web search routing' below — the 'Always search' option sends every request through the slower Agents API and disables device control for those turns.",
+          "web_search_mode": "'Let the model decide' (recommended): the AI searches only when it decides it needs to, and can still control your devices in the same turn. 'Always search': every request goes through the Agents API — slower, and device control does not work on those turns.",
+          "web_search_trigger": "Optional. Comma-separated phrases, for example 'search for, look up, google'. When set, these take precedence over the routing mode: only commands starting with one of these phrases search the web (the phrase itself is removed from the query), and all other commands never search. Leave empty to let the routing mode decide.",
           "stt_language": "Language for Voxtral speech-to-text. Select 'Auto-detect' to let Voxtral determine the language automatically.",
           "tts_voice": "Default voice used by Mistral TTS, if none is configured in the assistant settings.",
           "tts_mode": "Stream: low-latency SSE WAV with sentence-level pipelining. Batch: single mp3 request, higher latency but smaller responses cache well. The tts.speak service always uses batch."
@@ -63,6 +67,12 @@
       "options": {
         "stream": "Streaming",
         "batch": "Batch"
+      }
+    },
+    "web_search_mode": {
+      "options": {
+        "model": "Let the model decide (recommended)",
+        "always": "Always search (legacy, slower)"
       }
     }
   }

--- a/custom_components/mistral_conversation/translations/fr.json
+++ b/custom_components/mistral_conversation/translations/fr.json
@@ -39,6 +39,8 @@
           "max_tokens": "Nombre maximum de tokens dans la réponse",
           "continue_conversation": "Activer les conversations et écouter les réponses (Expérimental)",
           "web_search": "Activer la recherche sur le web (Beta)",
+          "web_search_mode": "Routage de la recherche web",
+          "web_search_trigger": "Phrases déclencheurs de recherche web (facultatif)",
           "stt_language": "Langage de la reconnaissance vocale (STT)",
           "tts_voice": "Voix de la transcription vocale (TTS)",
           "tts_mode": "Mode de synthèse vocale (TTS)"
@@ -51,6 +53,8 @@
           "max_tokens": "Longueur maximum de la réponse de l'IA en tokens.",
           "continue_conversation": "Quand activé, l'assistant continue automatiquement d'écouter après une réponse qui finit sur une question. Utilise le signal continue_conversation natif à HA. Expérimental : le comportement peut varier par satellite.",
           "web_search": "Quand activé, l'IA peut chercher sur internet pour des informations à jour. Utilise l'API Agents de Mistral (beta). Requiert un modèle qui prend en charge les agents (mistral-medium-latest ou mistral-large-latest).",
+          "web_search_mode": "« Laisser le modèle décider » (recommandé) : l'IA ne recherche que lorsqu'elle en a besoin et peut toujours contrôler vos appareils dans le même tour. « Toujours rechercher » : chaque requête passe par l'API Agents — plus lent, et le contrôle des appareils ne fonctionne pas dans ce cas.",
+          "web_search_trigger": "Facultatif. Phrases séparées par des virgules, par exemple « recherche, cherche en ligne, google ». Si renseigné, cela prime sur le mode de routage : seules les commandes commençant par l'une de ces phrases lancent une recherche web (la phrase est retirée de la requête) ; toutes les autres ne recherchent jamais. Laissez vide pour laisser le mode de routage décider.",
           "stt_language": "Langue utilisée pour la reconnaissance vocale (STT) de Voxtral. Selectionnez 'Auto-detect' Pour laisser Voxtral déterminer la langue de lui-même.",
           "tts_voice": "Voix par défaut utilisée par Mistral TTS, si aucune n'est configurée dans les paramètres de l'assistant.",
           "tts_mode": "Streaming : faible latence avec WAV en SSE et pipelining par phrase. Batch : une seule requête mp3, latence plus élevée mais réponses plus petites bien mises en cache. Le service tts.speak utilise toujours le mode batch."
@@ -63,6 +67,12 @@
       "options": {
         "stream": "Streaming",
         "batch": "Batch"
+      }
+    },
+    "web_search_mode": {
+      "options": {
+        "model": "Laisser le modèle décider (recommandé)",
+        "always": "Toujours rechercher (obsolète, plus lent)"
       }
     }
   }

--- a/custom_components/mistral_conversation/translations/nl.json
+++ b/custom_components/mistral_conversation/translations/nl.json
@@ -39,6 +39,8 @@
           "max_tokens": "Maximaal tokens in antwoord",
           "continue_conversation": "Gesprekken inschakelen en luisteren naar antwoorden (Experimenteel)",
           "web_search": "Webzoeken inschakelen (Beta)",
+          "web_search_mode": "Webzoeken-routering",
+          "web_search_trigger": "Triggerwoorden voor webzoeken (optioneel)",
           "stt_language": "Spraakherkenning taal (STT)",
           "tts_voice": "Tekst-naar-spraak stem",
           "tts_mode": "Tekst-naar-spraak modus"
@@ -51,6 +53,8 @@
           "max_tokens": "Maximale lengte van het AI-antwoord in tokens.",
           "continue_conversation": "Als ingeschakeld blijft de assistent automatisch luisteren na een antwoord dat eindigt met een vraag. Gebruikt de native HA continue_conversation vlag. Experimenteel: gedrag kan per satellite verschillen.",
           "web_search": "Als ingeschakeld kan de AI het web doorzoeken voor actuele informatie. Gebruikt Mistral's Agents API (beta). Vereist een model dat agents ondersteunt (mistral-medium-latest of mistral-large-latest).",
+          "web_search_mode": "'Laat het model beslissen' (aanbevolen): de AI zoekt alleen wanneer dat nodig is en kan in dezelfde opdracht nog steeds je apparaten bedienen. 'Altijd zoeken': elke opdracht gaat via de Agents API — langzamer, en apparaatbesturing werkt dan niet.",
+          "web_search_trigger": "Optioneel. Door komma's gescheiden zinnen, bijvoorbeeld 'zoek op, zoek online, google'. Als dit is ingevuld, gaat dit vóór de routering: alleen opdrachten die met zo'n zin beginnen zoeken op het web (de zin zelf wordt uit de zoekopdracht gehaald), alle andere opdrachten zoeken nooit. Laat leeg om de routering te laten beslissen.",
           "stt_language": "Taal voor Voxtral spraakherkenning. Laat leeg voor automatische detectie.",
           "tts_voice": "De standaardstem die door Mistral TTS wordt gebruikt als er geen stem is geconfigureerd in de assistentinstellingen.",
           "tts_mode": "Streaming: lage latentie via SSE WAV met pipelining per zin. Batch: één enkele mp3-aanvraag, hogere latentie maar kleinere antwoorden cachen goed. De tts.speak service gebruikt altijd batch."
@@ -63,6 +67,12 @@
       "options": {
         "stream": "Streaming",
         "batch": "Batch"
+      }
+    },
+    "web_search_mode": {
+      "options": {
+        "model": "Laat het model beslissen (aanbevolen)",
+        "always": "Altijd zoeken (verouderd, langzamer)"
       }
     }
   }

--- a/tests/test_web_search_routing.py
+++ b/tests/test_web_search_routing.py
@@ -1,0 +1,258 @@
+"""Tests for web-search routing.
+
+Covers the two pure pieces of the routing decision:
+
+* ``_resolve_trigger`` — optional trigger-phrase matching and query stripping.
+* ``_filter_intercepted_tool`` — removing the synthetic ``web_search`` tool call
+  from the delta stream before HA's ``chat_log`` sees it.
+
+Plus ``_web_search_tool_def`` (shape of the advertised tool) and the
+``_convert_chat_log_to_messages`` guard that drops content-less assistant turns
+left behind by an intercepted call.
+"""
+from __future__ import annotations
+
+import unittest
+from typing import Any, AsyncIterator
+
+from homeassistant.components import conversation as ha_conversation  # noqa: E402
+
+from . import _ha_stubs  # noqa: F401  side-effect: install HA stubs
+
+from mistral_conversation.const import WEB_SEARCH_TOOL_NAME  # noqa: E402
+from mistral_conversation.conversation import (  # noqa: E402
+    _convert_chat_log_to_messages,
+    _filter_intercepted_tool,
+    _resolve_trigger,
+    _web_search_tool_def,
+)
+
+
+class ResolveTriggerTests(unittest.TestCase):
+    """``_resolve_trigger`` matches phrases and strips them from the query."""
+
+    def test_empty_trigger_never_matches(self) -> None:
+        self.assertEqual(_resolve_trigger("zoek op het weer", ""), (False, "zoek op het weer"))
+
+    def test_whitespace_only_trigger_never_matches(self) -> None:
+        self.assertEqual(_resolve_trigger("anything", "  ,  , "), (False, "anything"))
+
+    def test_simple_match_strips_phrase(self) -> None:
+        self.assertEqual(_resolve_trigger("zoek op het weer", "zoek op"), (True, "het weer"))
+
+    def test_non_match_returns_text_unchanged(self) -> None:
+        self.assertEqual(
+            _resolve_trigger("zet de lamp aan", "zoek op, google"),
+            (False, "zet de lamp aan"),
+        )
+
+    def test_case_insensitive(self) -> None:
+        self.assertEqual(_resolve_trigger("ZOEK OP het weer", "zoek op"), (True, "het weer"))
+
+    def test_leading_whitespace_ignored(self) -> None:
+        self.assertEqual(_resolve_trigger("   zoek op iets", "zoek op"), (True, "iets"))
+
+    def test_colon_after_phrase_stripped(self) -> None:
+        self.assertEqual(_resolve_trigger("google: het weer", "google"), (True, "het weer"))
+
+    def test_multiple_phrases_any_matches(self) -> None:
+        trigger = "zoek op, zoek online, google"
+        self.assertEqual(_resolve_trigger("google het weer", trigger), (True, "het weer"))
+        self.assertEqual(_resolve_trigger("zoek online iets", trigger), (True, "iets"))
+
+    def test_longest_match_wins(self) -> None:
+        """A specific phrase must beat a prefix of itself."""
+        self.assertEqual(
+            _resolve_trigger("zoek online het weer", "zoek, zoek online"),
+            (True, "het weer"),
+        )
+
+    def test_phrase_only_utterance_yields_empty_query(self) -> None:
+        """Caller must treat this as 'no usable query' rather than searching ''."""
+        self.assertEqual(_resolve_trigger("google", "google"), (True, ""))
+
+    def test_phrase_must_be_at_start(self) -> None:
+        self.assertEqual(
+            _resolve_trigger("kun je google gebruiken", "google"),
+            (False, "kun je google gebruiken"),
+        )
+
+    def test_phrases_are_trimmed(self) -> None:
+        self.assertEqual(_resolve_trigger("google iets", "  google  "), (True, "iets"))
+
+
+class WebSearchToolDefTests(unittest.TestCase):
+    """The advertised tool must be a plain function tool Mistral accepts."""
+
+    def test_is_function_type(self) -> None:
+        self.assertEqual(_web_search_tool_def()["type"], "function")
+
+    def test_name_matches_constant(self) -> None:
+        self.assertEqual(
+            _web_search_tool_def()["function"]["name"], WEB_SEARCH_TOOL_NAME
+        )
+
+    def test_requires_query_parameter(self) -> None:
+        params = _web_search_tool_def()["function"]["parameters"]
+        self.assertIn("query", params["properties"])
+        self.assertEqual(params["required"], ["query"])
+
+    def test_description_warns_off_device_control(self) -> None:
+        """The description is the only steering signal the model gets."""
+        desc = _web_search_tool_def()["function"]["description"].lower()
+        self.assertIn("home", desc)
+
+
+class _FakeToolInput:
+    """Stand-in for llm.ToolInput with the attributes the filter reads."""
+
+    def __init__(self, tool_name: str, tool_args: Any) -> None:
+        self.tool_name = tool_name
+        self.tool_args = tool_args
+
+
+class FilterInterceptedToolTests(unittest.IsolatedAsyncioTestCase):
+    """``_filter_intercepted_tool`` hides our synthetic tool from chat_log."""
+
+    @staticmethod
+    async def _gen(items: list[dict[str, Any]]) -> AsyncIterator[dict[str, Any]]:
+        for item in items:
+            yield item
+
+    async def _run(
+        self, items: list[dict[str, Any]]
+    ) -> tuple[list[dict[str, Any]], list[str]]:
+        collected: list[str] = []
+        out = [
+            d
+            async for d in _filter_intercepted_tool(
+                self._gen(items), WEB_SEARCH_TOOL_NAME, collected
+            )
+        ]
+        return out, collected
+
+    async def test_non_tool_deltas_pass_through(self) -> None:
+        items = [{"role": "assistant"}, {"content": "hallo"}]
+        out, collected = await self._run(items)
+        self.assertEqual(out, items)
+        self.assertEqual(collected, [])
+
+    async def test_web_search_call_removed_and_query_collected(self) -> None:
+        items = [
+            {"role": "assistant"},
+            {"tool_calls": [_FakeToolInput(WEB_SEARCH_TOOL_NAME, {"query": "tour 2026"})]},
+        ]
+        out, collected = await self._run(items)
+        # The delta is suppressed entirely — chat_log rejects empty tool_calls.
+        self.assertEqual(out, [{"role": "assistant"}])
+        self.assertEqual(collected, ["tour 2026"])
+
+    async def test_other_tool_calls_are_preserved(self) -> None:
+        keep = _FakeToolInput("HassTurnOn", {"name": "tafellamp"})
+        out, collected = await self._run([{"tool_calls": [keep]}])
+        self.assertEqual(len(out), 1)
+        self.assertEqual(out[0]["tool_calls"], [keep])
+        self.assertEqual(collected, [])
+
+    async def test_mixed_delta_keeps_ha_tool_drops_web_search(self) -> None:
+        keep = _FakeToolInput("HassTurnOn", {"name": "tafellamp"})
+        drop = _FakeToolInput(WEB_SEARCH_TOOL_NAME, {"query": "weer"})
+        out, collected = await self._run([{"tool_calls": [keep, drop]}])
+        self.assertEqual(len(out), 1)
+        self.assertEqual(out[0]["tool_calls"], [keep])
+        self.assertEqual(collected, ["weer"])
+
+    async def test_query_is_stripped(self) -> None:
+        items = [{"tool_calls": [_FakeToolInput(WEB_SEARCH_TOOL_NAME, {"query": "  weer  "})]}]
+        _, collected = await self._run(items)
+        self.assertEqual(collected, ["weer"])
+
+    async def test_missing_query_is_dropped_not_collected(self) -> None:
+        items = [{"tool_calls": [_FakeToolInput(WEB_SEARCH_TOOL_NAME, {})]}]
+        out, collected = await self._run(items)
+        self.assertEqual(out, [])
+        self.assertEqual(collected, [])
+
+    async def test_blank_query_is_dropped_not_collected(self) -> None:
+        items = [{"tool_calls": [_FakeToolInput(WEB_SEARCH_TOOL_NAME, {"query": "   "})]}]
+        out, collected = await self._run(items)
+        self.assertEqual(out, [])
+        self.assertEqual(collected, [])
+
+    async def test_non_dict_args_do_not_raise(self) -> None:
+        items = [{"tool_calls": [_FakeToolInput(WEB_SEARCH_TOOL_NAME, "not-a-dict")]}]
+        out, collected = await self._run(items)
+        self.assertEqual(out, [])
+        self.assertEqual(collected, [])
+
+    async def test_multiple_searches_all_collected(self) -> None:
+        items = [
+            {"tool_calls": [_FakeToolInput(WEB_SEARCH_TOOL_NAME, {"query": "a"})]},
+            {"tool_calls": [_FakeToolInput(WEB_SEARCH_TOOL_NAME, {"query": "b"})]},
+        ]
+        out, collected = await self._run(items)
+        self.assertEqual(out, [])
+        self.assertEqual(collected, ["a", "b"])
+
+    async def test_delta_metadata_preserved_when_filtering(self) -> None:
+        keep = _FakeToolInput("HassTurnOn", {})
+        drop = _FakeToolInput(WEB_SEARCH_TOOL_NAME, {"query": "q"})
+        out, _ = await self._run([{"role": "assistant", "tool_calls": [keep, drop]}])
+        self.assertEqual(out[0]["role"], "assistant")
+
+
+class _Content:
+    """Base for chat_log content stubs (the real classes are stub types)."""
+
+    def __init__(self, **kwargs: Any) -> None:
+        for key, value in kwargs.items():
+            setattr(self, key, value)
+
+
+class _ChatLog:
+    def __init__(self, content: list[Any]) -> None:
+        self.content = content
+
+
+def _assistant(content: str | None, tool_calls: Any = None) -> Any:
+    obj = _Content(content=content, tool_calls=tool_calls)
+    obj.__class__ = type(
+        "AssistantContentStub", (ha_conversation.AssistantContent,), {}
+    )
+    obj.content = content
+    obj.tool_calls = tool_calls
+    return obj
+
+
+def _user(content: str) -> Any:
+    obj = ha_conversation.UserContent()
+    obj.content = content
+    return obj
+
+
+class ConvertChatLogEmptyAssistantTests(unittest.TestCase):
+    """Content-less assistant turns must not reach the Mistral payload.
+
+    An intercepted web_search call leaves an assistant turn with no text and no
+    surviving tool calls. Sending it yields HTTP 400 "Assistant message must
+    have either content or tool_calls, but not none." (code 3240).
+    """
+
+    def test_empty_assistant_turn_is_skipped(self) -> None:
+        chat_log = _ChatLog([_user("wie won de tour"), _assistant(None, None)])
+        messages = _convert_chat_log_to_messages(chat_log)
+        self.assertEqual(messages, [{"role": "user", "content": "wie won de tour"}])
+
+    def test_empty_string_assistant_turn_is_skipped(self) -> None:
+        chat_log = _ChatLog([_user("hoi"), _assistant("", None)])
+        messages = _convert_chat_log_to_messages(chat_log)
+        self.assertEqual(len(messages), 1)
+
+    def test_assistant_turn_with_text_is_kept(self) -> None:
+        chat_log = _ChatLog([_user("hoi"), _assistant("hallo", None)])
+        messages = _convert_chat_log_to_messages(chat_log)
+        self.assertEqual(messages[-1], {"role": "assistant", "content": "hallo"})
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Fixes #29.

With `web_search` enabled, every utterance that reached the LLM was routed
through the Agents/Conversations API. That cost latency on ordinary commands and
— because the Agents path never passed HA tools — silently broke device control:
the model replies "I can't perform physical actions" while the turn looks
successful and the light stays off.

Web search is now decided per turn.

## New options

**`web_search_mode`** (default `model`)

| Mode | Behaviour |
|---|---|
| `model` | Web search is advertised to the model as a tool. It searches only when it decides to, and HA tools stay on the request — so one turn can search *and* control devices. |
| `always` | Previous behaviour, kept for anyone relying on it. |

**`web_search_trigger`** (default empty) — optional comma-separated phrases.
When non-empty it takes precedence over `web_search_mode`: only utterances
starting with a phrase search (phrase stripped, longest match wins,
case-insensitive); all others never search. Empty by default because trigger
phrases are language-specific.

## Why the model route is a synthetic function tool

The obvious implementation — adding Mistral's built-in `{"type": "web_search"}`
to `tools` on `/v1/chat/completions` — does not work, despite the API reference
listing `WebSearchTool` in that endpoint's `tools` union:

```
HTTP 400 {"message":"WebSearchTool connector is not supported",
          "type":"invalid_tools","code":"1800"}
```

Reproduced on `mistral-medium-latest` and `mistral-large-latest`
(`web_search_premium` fails identically); a plain function tool on the same
request returns 200. The built-in tool is only honoured on `/v1/agents` and
`/v1/conversations`.

So we advertise an ordinary `web_search` function, intercept the call before it
reaches HA's `chat_log` (HA would otherwise try to execute a tool that isn't in
its LLM API), service it against the Agents API, and inject the result for the
next round. Search results live only in the outgoing payload, never in
`chat_log`, so conversation history stays a clean user/assistant transcript. The
tool is withdrawn after one use, so a turn can trigger at most one search and
cannot loop.

## Also fixed

An assistant turn with neither content nor tool calls — which an intercepted
call leaves behind — was sent to Mistral and rejected with HTTP 400 *"Assistant
message must have either content or tool_calls, but not none."* (code 3240).
Those turns are now skipped in `_convert_chat_log_to_messages`.

## Measured

| Utterance | Route | Time |
|---|---|---|
| "Zet de tafellamp aan" | `HassTurnOn`, fast path | 0.56 s |
| "Hoe warm is het in de woonkamer?" | `GetLiveContext`, fast path | 0.35 s |
| "Wie heeft de Tour de France 2026 gewonnen?" | model calls `web_search` → Agents API | 8.4 s |
| "Wat is de hoofdstad van Frankrijk?" | answered directly, no search | 0.53 s |

Verified end-to-end against the live API, including the combined case: a turn
that both searches and calls `HassTurnOn` returns the search answer *and*
performs the action.

## Tests

29 new tests in `tests/test_web_search_routing.py` covering trigger resolution
(matching, stripping, longest-match, colon/whitespace, phrase-only utterances),
tool-call interception (web search removed and collected, HA tools preserved,
mixed deltas, missing/blank/non-dict args), the advertised tool's shape, and the
content-less-assistant-turn guard.

110 tests total, all passing:

```
python -m unittest discover -t . -s tests
```

Each new guard was mutation-checked — reverting it turns the suite red.

## Backwards compatibility

Existing configs keep working; both options have defaults. One deliberate
behaviour change: users with `web_search: true` move from always-search to
model-decided, on the assumption that working device control is preferable to
the old behaviour. Happy to default `web_search_mode` to `always` instead if you
prefer strict compatibility — one-line change.